### PR TITLE
fix: change gcode for bed_temp to hotend_temp

### DIFF
--- a/config/sovol-macros.cfg
+++ b/config/sovol-macros.cfg
@@ -43,15 +43,15 @@ gcode:
 
     {% set extruder_target_temp = 150 %}
 
-    {% set bed_targer_temp = bedtemp|int %}
+    {% set bed_target_temp = bedtemp|int %}
 
     M400
 
     CLEAR_PAUSE
 
     # set minimum temperature to heat to mesh calibrate temperature
-    {% if bed_targer_temp <= mesh_calibrate_temp %}
-        {% set bed_targer_temp = mesh_calibrate_temp %}
+    {% if bed_target_temp <= mesh_calibrate_temp %}
+        {% set bed_target_temp = mesh_calibrate_temp %}
     {% endif %}
 
     # set minimum extruder temp to 150, heats up faster later and good for the offset calibration/nozzle cleaning.
@@ -78,10 +78,10 @@ gcode:
 
         {action_respond_info("Check Heating!")}
 
-        {% if printer.heater_bed.temperature < bed_targer_temp %}
+        {% if printer.heater_bed.temperature < bed_target_temp %}
             M117 Bed heating...
             {action_respond_info("Bed heating...")}
-            M190 S{bed_targer_temp}
+            M190 S{bed_target_temp}
         {% endif %}
 
         {% if printer.extruder.temperature < extruder_target_temp %}
@@ -90,7 +90,7 @@ gcode:
             M109 S{extruder_target_temp} 
         {% endif %}
 
-        M140 S{bed_targer_temp}
+        M140 S{bed_target_temp}
         M104 S{extruder_target_temp}
 
         

--- a/config/sovol-macros.cfg
+++ b/config/sovol-macros.cfg
@@ -539,10 +539,10 @@ gcode:
                 G1 E10 F150
                 G90
             {% else %}
-                M140 S{extruder_target_temp}
+                M104 S{extruder_target_temp}
                 {action_respond_info("Nozzle not hot enough!")}
                 {action_respond_info("Nozzle heating...")}
-                M190 S{extruder_target_temp}
+                M109 S{extruder_target_temp}
                 G91
                 G1 E30 F300
                 G1 E10 F150


### PR DESCRIPTION
Seems like Sovol accidentally used the M140 and M190 (for bed heater) gcodes to set temp and wait for the hotend, which should be M104 and M109 instead.

Originally found by Ake Wallebom on FB, shared by Gergo on YT (https://www.youtube.com/watch?v=Yva6pBgEr5M)

GCode Reference:
https://marlinfw.org/docs/gcode/M140.html
https://marlinfw.org/docs/gcode/M190.html

https://marlinfw.org/docs/gcode/M104.html
https://marlinfw.org/docs/gcode/M109.html