### PR TITLE
Streamlined fan config

### DIFF
--- a/config/options/lcd/sovol-menu.cfg
+++ b/config/options/lcd/sovol-menu.cfg
@@ -76,7 +76,7 @@ gcode:
 [menu __main __tune __fanspeed]
 type: input
 name: Fan speed: {'%3d' % (menu.input*100)}%
-input: {printer["fan_generic fan0"].speed}
+input: {printer["fan"].speed}
 input_min: 0
 input_max: 1
 input_step: 0.01
@@ -116,15 +116,26 @@ input_step: 1
 gcode: 
     M140 S{'%.0f' % menu.input}
 
+[menu __main __tune __exhaustfanonoff]
+type: command
+name: Exhaust Fan {'ON' if printer['fan_generic exhaust_fan'].speed > 0 else 'OFF'}
+enable: {'fan_generic exhaust_fan' in printer}
+gcode:
+    {% if printer['fan_generic exhaust_fan'].speed > 0 %}
+      SET_FAN_SPEED FAN=exhaust_fan SPEED=0
+    {% else %}
+      SET_FAN_SPEED FAN=exhaust_fan SPEED=1
+    {% endif %}
+
 [menu __main __tune __exhaustfanspeed]
 type: input
-name: ExhaustFan:{'%3d' % (menu.input*100)}%
-input: {printer["fan_generic fan3"].speed}
+name: Exhaust Fan:{'%3d' % (menu.input*100)}%
+input: {printer["fan_generic exhaust_fan"].speed}
 input_min: 0
 input_max: 1
 input_step: 0.01
 gcode:
-    M106 P3 S{'%d' % (menu.input*255)}
+    SET_FAN_SPEED FAN=exhaust_fan SPEED={menu.input}
 
 # yay dimming - MON5TERMATT
 [menu __main __tune __ledonoff]
@@ -352,22 +363,33 @@ gcode:
 [menu __main __control2 __fanspeed]
 type: input
 name: Fan speed: {'%3d' % (menu.input*100)}%
-input: {printer["fan_generic fan0"].speed}
+input: {printer["fan"].speed}
 input_min: 0
 input_max: 1
 input_step: 0.01
 gcode:
     M106 S{'%d' % (menu.input*255)}
 
+[menu __main __control2 __exhaustfanonoff]
+type: command
+name: Exhaust Fan {'ON' if printer['fan_generic exhaust_fan'].speed > 0 else 'OFF'}
+enable: {'fan_generic exhaust_fan' in printer}
+gcode:
+    {% if printer['fan_generic exhaust_fan'].speed > 0 %}
+      SET_FAN_SPEED FAN=exhaust_fan SPEED=0
+    {% else %}
+      SET_FAN_SPEED FAN=exhaust_fan SPEED=1
+    {% endif %}
+
 [menu __main __control2 __exhaustfanspeed]
 type: input
-name: ExhaustFan:{'%3d' % (menu.input*100)}%
-input: {printer["fan_generic fan3"].speed}
+name: Exhaust Fan:{'%3d' % (menu.input*100)}%
+input: {printer["fan_generic exhaust_fan"].speed}
 input_min: 0
 input_max: 1
 input_step: 0.01
 gcode:
-    M106 P3 S{'%d' % (menu.input*255)}
+    SET_FAN_SPEED FAN=exhaust_fan SPEED={menu.input}
 
 # yay dimming - MON5TERMATT
 [menu __main __control2 __ledonoff]

--- a/config/printer.cfg
+++ b/config/printer.cfg
@@ -296,23 +296,15 @@ fade_start: 0
 fade_end: 10
 fade_target: 0           
 
-# [fan_generic fan0] # back model cooling fan
-# pin: extra_mcu:PA7
-# max_power: 1.0
-
-# [fan_generic fan1] # front model cooling fan
-# pin: extra_mcu:PB1
-# max_power: 1.0
-
 [multi_pin print_cooling_fan_pins]
 pins: extra_mcu:PA7, extra_mcu:PB1
 
 # print/part cooling fan
-[fan_generic cooling]
+[fan]
 pin: multi_pin:print_cooling_fan_pins
 max_power: 1.0
 
-[fan_generic fan3] # exhaust fan
+[fan_generic exhaust_fan] # exhaust fan
 pin: PA2
 max_power: 1.0
 

--- a/config/sovol-macros.cfg
+++ b/config/sovol-macros.cfg
@@ -70,6 +70,9 @@ gcode:
             CANCEL_PRINT
         {% endif %}
 
+        #Start exhaust fan
+        #SET_FAN_SPEED FAN=exhaust_fan SPEED=1
+
         {action_respond_info("Check Heating!")}
 
         {% if printer.heater_bed.temperature < bed_target_temp %}
@@ -168,9 +171,15 @@ gcode:
      TURN_OFF_HEATERS
     {% endif %}
 
+[delayed_gcode exhaust_fan_off]
+gcode:
+    SET_FAN_SPEED FAN=exhaust_fan SPEED=0
+
 [gcode_macro _ALL_FAN_OFF]
 gcode:
     M106 S0
+    # Run the exhaust fan for another 2min after the other fans and then turn it off
+    # UPDATE_DELAYED_GCODE ID=exhaust_fan_off DURATION=120
     M107
 
 [gcode_macro CLEAN_NOZZLE] 
@@ -669,24 +678,6 @@ gcode:
         TEMPERATURE_WAIT SENSOR=heater_bed MINIMUM={s-1} MAXIMUM={s+1}  
     {% endif %}
 
-[gcode_macro M106]
-gcode:
-    {% set fan = 'fan' + (params.P|int if params.P is defined else 0)|string %}
-    {% set speed = (params.S|float / 255 if params.S is defined else 1.0) %}
-    {% if fan == 'fan3'%}
-            SET_FAN_SPEED FAN={fan} SPEED={speed}
-    {% else %}
-        SET_FAN_SPEED FAN={'cooling'} SPEED={speed}
-    {% endif %}
-    
-[gcode_macro M107]
-gcode:
-    {% set fan = 'fan' + (params.P|int if params.P is defined else 0)|string %}
-    {% if fan == 'fan3'%}
-            SET_FAN_SPEED FAN={fan} SPEED=0
-    {% else %}
-        SET_FAN_SPEED FAN={'cooling'} SPEED=0
-    {% endif %}
     
 [gcode_macro M600]
 gcode:


### PR DESCRIPTION
Addresses #17

Printer config
- changed part cooling fan from [generic_fan] to [fan]
- renamed fan3 to exhaust_fan

Macros
- removed M106 and M107 overrides since [fan] is now defined
- added delayed_gcode to turn off exhaust fan after a certain amount of time
- added a commented out section to use the delayed gcode in end_print and option to turn it on in start_print

LCD
- fixed fan speed control of part cooling fan
- added ON/OFF control for exhaust fan and changed M106 to SET_FAN_SPEED for exhaust_fan control

Note: My SV08 is still stuck somewhere in transit :') config looks good to me, but I'd appreciate if someone could test this real quick.