### PR TITLE
changed to appropriate languages for syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Please SSH into your printer and then do the following steps.
    make install
    ```
    - Then edit your `moonraker.conf` and add the following lines:
-   ```bash
+   ```ini
    [update_manager timelapse]
    type: git_repo
    primary_branch: main
@@ -317,7 +317,7 @@ Next, we have to configure our printer and put back some addons Sovol has added 
      -> G-code<br>
      -> Change your 'START_PRINT' line to this:<br>
 
-     ```
+     ```gcode
       START_PRINT EXTRUDER_TEMP=[nozzle_temperature_initial_layer] BED_TEMP=[bed_temperature_initial_layer_single]
      ```
 


### PR DESCRIPTION
.cfg files and other configs work best using ini for syntax highlighting.

gcode syntax highlighting also exists. Though non-standard gcode doesn't work well, but I think it's better to have it here so it can be copied from in the future.