### PR TITLE
User BED_TEMP to QGL

### DIFF
--- a/config/sovol-macros.cfg
+++ b/config/sovol-macros.cfg
@@ -90,21 +90,23 @@ gcode:
         M140 S{bed_target_temp}
         M104 S{extruder_target_temp}
 
-        
         {% if heatsoak == True %}
           M117 Short Heat Soak
+          {action_respond_info("Short Heat Soak...")}
           G4 P{heatsoak_time * 60000} # pause for x number of minute(s) (see variable_heat_soak_time)
         {% endif %}
         
         {% if printer.quad_gantry_level.applied|lower != 'true' %}
             M117 QGL
-            QUAD_GANTRY_LEVEL
+            {action_respond_info("QGL...")}
+            QUAD_GANTRY_LEVEL BED_TEMP={bed_target_temp}
             M117 Home Z after QGL
             G28 Z # And once again after QGL, important..
             # M117 Auto Z Offset
             # Z_OFFSET_CALIBRATION
         {% endif %}
         M117 Bed Mesh
+        {action_respond_info("Bed Mesh...")}
         BED_MESH_CALIBRATE ADAPTIVE=1 
         
         SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=state VALUE='"Start"' 
@@ -294,14 +296,15 @@ gcode:
     {% set mesh_name = "default" %}
     {% set mesh_calibrate_temp = printer['gcode_macro _global_var'].bed_mesh_calibrate_target_temp|int %}
     {% set current_target_temp  = printer.heater_bed.target|int %}
+    {% set bedtemp = params.BED_TEMP|default(mesh_calibrate_temp)|int %}
 
     {action_respond_info("Check Heating!")}
-    {% if printer.heater_bed.temperature != mesh_calibrate_temp %}
-        M140 S{mesh_calibrate_temp}
+    {% if printer.heater_bed.temperature != bedtemp %}
+        M140 S{bedtemp}
         {action_respond_info("The bed target temperature was not reached!")}
         {action_respond_info("Bed heating...")}
-        {% if current_target_temp <= mesh_calibrate_temp %}
-          M190 S{mesh_calibrate_temp}
+        {% if current_target_temp <= bedtemp %}
+          M190 S{bedtemp}
         {% else %}
           M190 S{current_target_temp}
         {% endif %}


### PR DESCRIPTION
If the user set a Parameter for the Bed Temp at START_PRINT it will also put these value to the QGL.

Testet it an working, BED_TEMP must be higher than variable_bed_mesh_calibrate_target_temp