### PR TITLE
Two more tweaks to M117 messages.

### DIFF
--- a/files-used/config/sovol-macros.cfg
+++ b/files-used/config/sovol-macros.cfg
@@ -132,7 +132,7 @@ gcode:
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=record_extruder_temp VALUE=0  
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=max_record_extruder_temp VALUE=0
 
-    M117 Print finished.
+    M117 Done
     G91
     {% if printer['filament_switch_sensor filament_sensor'].enable == True and
           printer['filament_switch_sensor filament_sensor'].filament_detected == True
@@ -652,7 +652,7 @@ gcode:
         G1 E-50 F300 
         G90
         M400
-        M117 Filament unloaded.
+        M117 Filament ejected.
         M400
         {% if current_target_temp == 0 or printer.print_stats.state != "paused"%}
             M104 S0


### PR DESCRIPTION
"Filament unloaded." was two characters too wide for the LCD, so go with "ejected" instead.

Also, "Print finished." looked a bit odd with the lowercase f, so change to "Done" instead, which matches "Ready" that the printer normally outputs on start.