### PR TITLE
Adjust config options for use with both stock LCD and touchscreen

### DIFF
--- a/files-used/config/options/lcd/lcd.cfg
+++ b/files-used/config/options/lcd/lcd.cfg
@@ -38,11 +38,3 @@ color_order: RGB
 initial_RED: 0.5             
 initial_GREEN: 0.4           
 initial_BLUE: 0.7           
-
-# While using the LCD this makes sense. 
-# But when using the HDMI screen it makes more sense to label this as a LED instead of a pin.
-[output_pin main_led]
-pin:PA3
-pwm: 1
-value:1
-cycle_time: 0.010

--- a/files-used/config/options/lcd/sovol-menu.cfg
+++ b/files-used/config/options/lcd/sovol-menu.cfg
@@ -137,16 +137,17 @@ input_step: 0.01
 gcode:
     SET_FAN_SPEED FAN=exhaust_fan SPEED={menu.input}
 
+# Moved to options/led/lcd.cfg
 # yay dimming - MON5TERMATT
-[menu __main __tune __ledonoff]
-type: input
-enable: {'output_pin main_led' in printer}
-name: Dim LED:    {'%3d%s' % (menu.input*100,'%') if menu.input else 'OFF'}
-input: {printer['output_pin main_led'].value}
-input_min: 0.0
-input_max: 1.0
-input_step: 0.01
-gcode: SET_PIN PIN=main_led VALUE={menu.input}
+#[menu __main __tune __ledonoff]
+#type: input
+#enable: {'output_pin main_led' in printer}
+#name: Dim LED:    {'%3d%s' % (menu.input*100,'%') if menu.input else 'OFF'}
+#input: {printer['output_pin main_led'].value}
+#input_min: 0.0
+#input_max: 1.0
+#input_step: 0.01
+#gcode: SET_PIN PIN=main_led VALUE={menu.input}
 
 [menu __main __tune __save]
 type: list

--- a/files-used/config/options/led/hdmi.cfg
+++ b/files-used/config/options/led/hdmi.cfg
@@ -4,3 +4,11 @@ white_pin:PA3
 cycle_time: 0.010
 hardware_pwm: False
 initial_WHITE: 1.0
+
+[gcode_macro MAINLED_ON]
+gcode:
+    SET_LED LED=main_led WHITE=1
+
+[gcode_macro MAINLED_OFF]
+gcode:
+    SET_LED LED=main_led WHITE=0

--- a/files-used/config/options/led/lcd.cfg
+++ b/files-used/config/options/led/lcd.cfg
@@ -1,0 +1,27 @@
+# While using the LCD this makes sense. 
+# But when using the HDMI screen it makes more sense to label this as a LED instead of a pin.
+[output_pin main_led]
+pin:PA3
+pwm: 1
+value:1
+cycle_time: 0.010
+
+[gcode_macro MAINLED_ON]
+gcode:
+    SET_PIN PIN=main_led VALUE=1
+
+[gcode_macro MAINLED_OFF]
+gcode:
+    SET_PIN PIN=main_led VALUE=0
+
+# LCD screen menu
+# yay dimming - MON5TERMATT
+[menu __main __tune __ledonoff]
+type: input
+enable: {'output_pin main_led' in printer}
+name: Dim LED:    {'%3d%s' % (menu.input*100,'%') if menu.input else 'OFF'}
+input: {printer['output_pin main_led'].value}
+input_min: 0.0
+input_max: 1.0
+input_step: 0.01
+gcode: SET_PIN PIN=main_led VALUE={menu.input}

--- a/files-used/config/printer.cfg
+++ b/files-used/config/printer.cfg
@@ -7,8 +7,10 @@
 # IF YOU ARE USING THE SCREEN THAT COMES WITH THE SV08
 [include options/lcd/*.cfg]
 
-# IF YOU HAVE KLIPPERSCREEN / AN HDMI DISPLAY ATTACHED TO YOUR PRINTER
-# [include options/hdmi/*.cfg]
+# Choose whether you would rather control your LEDs with the LCD screen or KlipperScreen
+# THESE ARE INCOMPATIBLE WITH EACH OTHER; ONLY ENABLE ONE
+[include options/led/lcd.cfg]
+#[include options/led/hdmi.cfg]
 
 # If you are using the stock probe, keep the following lines as-is.
 # If you have an Eddy probe, comment the first and uncomment the second,

--- a/files-used/config/sovol-macros.cfg
+++ b/files-used/config/sovol-macros.cfg
@@ -1,13 +1,4 @@
-[gcode_macro mainled_on]
-gcode:
-    SET_PIN PIN=main_led VALUE=1
-
-[gcode_macro mainled_off]
-gcode:
-    SET_PIN PIN=main_led VALUE=0
-
-#--------------------------------------------------------------------#
-#--------------------------------------------------------------------#
+# mainled macros defined in options/led/*
 
 [force_move]
 enable_force_move: True


### PR DESCRIPTION
Moved LED configuration to a separate folder in options/led.

Moved LCD led control into options/led/lcd.cfg

Moved the macro for mainled into this folder so the correct macro is defined based on whether it is defined as a pin or led.

Removed the hdmi folder for now as it is empty. Can add it back if more configuration for the hdmi option is added.