### PR TITLE
re-enable usb auto mount feature

### DIFF
--- a/usbmount/60-usbmount.rules
+++ b/usbmount/60-usbmount.rules
@@ -1,0 +1,5 @@
+# mount the device when added
+KERNEL=="sd[a-z]*", ACTION=="add",  	RUN+="/usr/bin/systemctl --no-block restart makerbase-automount@%k.service"
+
+# clean up after device removal
+KERNEL=="sd[a-z]*", ACTION=="remove",	RUN+="/usr/bin/systemctl --no-block restart makerbase-automount@%k.service"

--- a/usbmount/Makefile
+++ b/usbmount/Makefile
@@ -1,0 +1,13 @@
+.PHONY: install
+install:
+	install -D makerbase-automount $(DESTDIR)$(PREFIX)/bin/makerbase-automount
+	install -Dm644 60-usbmount.rules $(DESTDIR)$(PREFIX)/lib/udev/rules.d/60-usbmount.rules
+	install -Dm644 makerbase-automount@.service $(DESTDIR)$(PREFIX)/lib/systemd/system/makerbase-automount@.service
+	install -d $(DESTDIR)/etc/makerbase-automount.d
+	install -Cm644 makerbase-automount.d/* $(DESTDIR)/etc/makerbase-automount.d/
+
+clean:
+	sudo rm $(DESTDIR)$(PREFIX)/bin/makerbase-automount
+	sudo rm $(DESTDIR)$(PREFIX)/lib/udev/rules.d/60-usbmount.rules
+	sudo rm $(DESTDIR)$(PREFIX)/lib/systemd/system/makerbase-automount@.service
+	sudo rm -rf $(DESTDIR)/etc/makerbase-automount.d

--- a/usbmount/README.md
+++ b/usbmount/README.md
@@ -1,0 +1,53 @@
+# Auto-Mount USB Stick for Sovol SV08
+
+## Overview
+This script automatically mounts a USB stick and lists G-code files in the LCD `SDCard` menu. This functionality was missing after installing mainline Klipper on the Sovol SV08. The code is based on the open-source Sovol GitHub repository for SV08, which can be found [here](https://github.com/Sovol3d/SV08/tree/main/home/sovol/usbmount).
+
+## Installation
+
+1. Upload this folder to the `/home/biqu` directory on your SV08 using an SCP tool.
+2. SSH into your SV08.
+3. Run the following commands:
+
+```bash
+cd /home/biqu/usbmount
+sudo make install PREFIX=/usr
+```
+
+This will install the necessary files and you should see the following output in the terminal:
+
+```bash
+install -D makerbase-automount /usr/bin/makerbase-automount
+install -Dm644 60-usbmount.rules /usr/lib/udev/rules.d/60-usbmount.rules
+install -Dm644 makerbase-automount@.service /usr/lib/systemd/system/makerbase-automount@.service
+install -d /etc/makerbase-automount.d
+install -Cm644 makerbase-automount.d/* /etc/makerbase-automount.d/
+```
+
+## Uninstallation
+
+To remove the installation, run:
+
+```bash
+cd /home/biqu/usbmount
+sudo make clean PREFIX=/usr
+```
+
+The following files will be deleted:
+
+```bash
+sudo rm /usr/bin/makerbase-automount
+sudo rm /usr/lib/udev/rules.d/60-usbmount.rules
+sudo rm /usr/lib/systemd/system/makerbase-automount@.service
+sudo rm -rf /etc/makerbase-automount.d
+```
+
+## Features
+
+1. Automatically lists G-code files from the USB stick under the `SDCard` menu on the LCD
+2. Allows configuration of WiFi settings through `wifi.cfg` file in USB stick
+  - If the SSID in `wifi.cfg` matches the current WiFi SSID, the file is renamed to `wifi.cfg.unchanged`.
+  - If the SSID in `wifi.cfg` is different from the current SSID, the system will attempt to connect to the new network:
+    - If the connection is successful, `wifi.cfg` will be renamed to `wifi.cfg.setup`.
+    - If the connection fails, `wifi.cfg` will be renamed to `wifi.cfg.invalid`.
+3. The log for mounting USB stick is written `/tmp/usbmount.log`

--- a/usbmount/makerbase-automount
+++ b/usbmount/makerbase-automount
@@ -1,0 +1,74 @@
+#!/bin/sh
+
+user_id="biqu"
+
+mediadir="/mnt/USB"
+
+target_dir="/home/$user_id/printer_data/gcodes"
+
+dev=/dev/${1##*/}
+
+if ! [ -b $dev ]
+then
+	if grep /etc/mtab -qe "^$dev"
+	then
+	    rm -f /home/$user_id/printer_data/gcodes/USB-*.gcode
+		umount "$dev"
+		echo "umount $dev success" >> /tmp/usbmount.log
+		rmdir $mediadir
+	fi
+	exit 0
+fi
+
+echo "exec mount $1" >> /tmp/usbmount.log
+mkdir -p $mediadir
+#if [ $? -ne 0 ]; then
+#	echo "mkdir failed" >> /tmp/usbmount.log
+#else
+#	echo "mkdir successed" >> /tmp/usbmount.log
+#fi
+sudo mount -t auto -o uid=$user_id -o gid=$user_id $dev $mediadir
+
+prefix="USB-"
+
+# symbol link all gcode file in USB stick to /home/biqu/printer_data/gcodes/ with USB- prefix
+
+for file in "$mediadir"/*.gcode; do
+    filename=$(basename "$file")
+    target_file="$target_dir/$prefix$filename"
+    cp "$file" "$target_file" 2>> /tmp/usbmount.log
+done
+
+# Path to the wifi.cfg file
+CONFIG_FILE="$mediadir/wifi.cfg"
+
+# Check if the config file exists
+if [ -f "$CONFIG_FILE" ]; then
+    # Extract ssid and password from the config file
+    SSID=$(grep 'ssid' $CONFIG_FILE | cut -d'=' -f2 | tr -d '\r\n')
+    PASSWORD=$(grep 'password' $CONFIG_FILE | cut -d'=' -f2 | tr -d '\r\n')
+
+    # Check if you're already connected to the specified SSID
+    CURRENT_SSID=$(nmcli -t -f active,ssid dev wifi | grep '^yes' | cut -d':' -f2)
+    
+    if [ "$CURRENT_SSID" == "$SSID" ]; then
+        echo "Already connected to $SSID." | sudo tee /dev/kmsg
+        mv $CONFIG_FILE "$CONFIG_FILE.unchanged"
+    else
+        # Connect to the WiFi network
+        nmcli dev wifi connect "$SSID" password "$PASSWORD"
+
+        # Check if the connection was successful
+        if [ $? -eq 0 ]; then
+            echo "Connected to $SSID successfully." | sudo tee /dev/kmsg
+            mv $CONFIG_FILE "$CONFIG_FILE.setup"
+        else
+            echo "Failed to connect to $SSID." | sudo tee /dev/kmsg
+            mv $CONFIG_FILE "$CONFIG_FILE.invalid"
+        fi
+    fi
+else
+    echo "Wifi config file not found: $CONFIG_FILE" | sudo tee /dev/kmsg
+    # Exit with a non-zero status to indicate failure
+    # exit 1
+fi

--- a/usbmount/makerbase-automount.d/auto
+++ b/usbmount/makerbase-automount.d/auto
@@ -1,0 +1,8 @@
+# -*- sh -*-
+
+# Options to use for auto-mounting generic filesystems
+AUTOMOUNT_OPTS='users'
+
+# Type to use for auto-mounting generic filesystems
+AUTOMOUNT_TYPE=auto
+

--- a/usbmount/makerbase-automount.d/hfsplus
+++ b/usbmount/makerbase-automount.d/hfsplus
@@ -1,0 +1,5 @@
+# -*- sh -*-
+
+# Options to use for auto-mounting devices detected with an hfsplus filesystem 
+AUTOMOUNT_OPTS=ro,users,relatime
+

--- a/usbmount/makerbase-automount.d/ntfs
+++ b/usbmount/makerbase-automount.d/ntfs
@@ -1,0 +1,8 @@
+# -*- sh -*-
+
+# Mount options to use for auto-mounting NTFS drives
+AUTOMOUNT_OPTS='errors=remount-ro,relatime,utf8,users,flush'
+
+# If NTFS-3G is installed, use it as the mount type
+hash ntfs-3g && AUTOMOUNT_TYPE="ntfs-3g"
+

--- a/usbmount/makerbase-automount.d/vfat
+++ b/usbmount/makerbase-automount.d/vfat
@@ -1,0 +1,5 @@
+# -*- sh -*-
+
+# Options to use for auto-mounting devices detected with a vfat filesystem 
+AUTOMOUNT_OPTS='errors=remount-ro,relatime,utf8,users,flush,gid=100,dmask=000,fmask=111'
+

--- a/usbmount/makerbase-automount@.service
+++ b/usbmount/makerbase-automount@.service
@@ -1,0 +1,4 @@
+[Service]
+Type=forking
+GuessMainPID=no
+ExecStart=/usr/bin/makerbase-automount %I


### PR DESCRIPTION
## Overview
This script automatically mounts a USB stick and lists G-code files in the LCD `SDCard` menu. This functionality was missing after installing mainline Klipper on the Sovol SV08. The code is based on the open-source Sovol GitHub repository for SV08, which can be found [here](https://github.com/Sovol3d/SV08/tree/main/home/sovol/usbmount).