### PR TITLE
Image expandability on the 1st boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ Ok, now you can continue.
 # STEP 2 - FLASHING MEDIA
 
 First, download the BIGTREETECH CB1 Linux image (the original Sovol SV08 image was also based on this): [https://github.com/bigtreetech/CB1](https://github.com/bigtreetech/CB1/releases)
-
+>[!NOTE]
+>Regardless of the medium (SD card or eMMC) or the size the BIGTREETECH CB1 Linux image will expand the size of the image to the full size of the card being used.
 Here we can use 3 methods:
 
 **Method 1**: Write the CB1 image directly to the eMMC and use it that way

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Ok, now you can continue.
 First, download the BIGTREETECH CB1 Linux image (the original Sovol SV08 image was also based on this): [https://github.com/bigtreetech/CB1](https://github.com/bigtreetech/CB1/releases)
 >[!NOTE]
 >Regardless of the medium (SD card or eMMC) or the size the BIGTREETECH CB1 Linux image will expand the size of the image to the full size of the card being used.
+>
 Here we can use 3 methods:
 
 **Method 1**: Write the CB1 image directly to the eMMC and use it that way


### PR DESCRIPTION
Hi,
I just added an info about the image expandability on the 1st boot. It may come hand for those wishing to use bigger than 8GB eMMC/SD Card.
I personally was wondering if I would need to expand the image manually after booting.