### PR TITLE
update readme to address wifi bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,12 @@ To make the CB1 image setup correctly we need to copy a file and make a few chan
 
 5. Change the Wi-Fi credentials in the 'system.cfg'
 
+> [!NOTE]
+> If you have the special character '$' in you wifi password, it is recommended that you escape ('\') the character.  The bash process of reading the system.cfg reads the in '$' and converts it.  For example, a WIFI_PASSWD of '1$234' should be saved in the system.cfg as '1\$234'.
+
    - Optional: uncomment the hostname and set the hostname to e.g. "SV08"
    - Save changes to the system.cfg
+
 
 > [!IMPORTANT]
 > if you are using an HDMI screen you will need to set the screen rotation to "inverted"


### PR DESCRIPTION

There is a bug in the way the wifi info is transferred from the system.cfg file.  It results in '$' in the WIFI password being converted.  For example a WIFI password with '1234$$' is read in as '12345973'.  Or '1234$5' results in '1234'.   
The simple fix is to escape the special characters.   It seems to only occurs with '$'?

 I've only added a note in the README.  Maybe I'll look into creating a fix, but for now this should help.  

```
simple test of the issue:

$ SYSTEM_CFG_PATH="system.cfg"
$ source ${SYSTEM_CFG_PATH}
$ echo $WIFI_PASSWD
$ 12345973

```